### PR TITLE
sync cart item details with product edit action

### DIFF
--- a/client/src/features/cart/cart.js
+++ b/client/src/features/cart/cart.js
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import db from "../../services/db_query";
+import { editProduct } from "../products/products";
 
 const initialState = [];
 
@@ -27,6 +28,13 @@ export const checkoutCart = createAsyncThunk(
   }
 );
 
+const updateCartItem = (updatedProduct, cartItem) => {
+  const cartItemCopy = JSON.parse(JSON.stringify(cartItem));
+  cartItemCopy.title = updatedProduct.title;
+  cartItemCopy.price = updatedProduct.price;
+  return cartItemCopy;
+}
+
 const cartSlice = createSlice({
   name: "cart",
   initialState,
@@ -43,6 +51,16 @@ const cartSlice = createSlice({
     builder.addCase(checkoutCart.fulfilled, (state, action) => {
       return [];
     });
+    builder.addCase(editProduct.fulfilled, (state, action) => {
+      const updatedProduct = action.payload;
+      const modifiedItems = state.map(item => {
+        if (item.productId === updatedProduct._id) {
+          return updateCartItem(updatedProduct, item);
+        }
+        return item;
+      });
+      return modifiedItems;
+    })
   }
 });
 

--- a/client/src/features/products/products.js
+++ b/client/src/features/products/products.js
@@ -50,10 +50,6 @@ export const editProduct = createAsyncThunk(
   }
 );
 
-// export const decrementProduct = createAsyncThunk(
-//   "products/addItemToCart", (item) => item);
-
-
 const productSlice = createSlice({
   name: "products",
   initialState,
@@ -64,24 +60,24 @@ const productSlice = createSlice({
     });
     builder.addCase(addProduct.fulfilled, (state, action) => {
       return state.concat(action.payload);
-    })
+    });
     builder.addCase(deleteProduct.fulfilled, (state, action) => {
       const deletedId = action.payload
       return state.filter(item => item._id !== deletedId);
-    })
+    });
     builder.addCase(editProduct.fulfilled, (state, action) => {
       const updatedInventory = [...state];
       const indexOfUpdated = updatedInventory.findIndex(item => item._id === action.payload._id)
       updatedInventory.splice(indexOfUpdated, 1, action.payload);
       return updatedInventory;
-    })
+    });
     builder.addCase(addItemToCart.fulfilled, (state, action) => {
       const id = action.payload.product._id;
       const modifiedItems = state.map(item => {
         return item._id === id ? action.payload.product : item
       })
       return modifiedItems;
-    })
+    });
   }
 });
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -122,7 +122,24 @@ router.put("/products/:id", (req, res) => {
     })
     .then((updatedProduct) => {
       res.json(updatedProduct);
-    });
+    })
+    .then(() => {
+      CartItem.findOne({
+        productId,
+      })
+      .then((item) => {
+        if (item) {
+          return CartItem.findOneAndUpdate(
+            { productId },
+            {
+              title,
+              price
+            },
+            { new: true}
+          );
+        }
+      })
+    })
 });
 
 router.delete("/products/:id", (req, res, next) => {


### PR DESCRIPTION
Added functionality to update cart item title and or price when a corresponding product item is edited. 

Specifically I...

1) modified the server API so that a `put` request to `/products/:id` updates the details of cart item after a product has been successfully edited. This more or less follows the pattern of a `post` to the path `/add-to-cart`
2) added `editProduct.fulfilled` as a case to the `cartSlice` reducers